### PR TITLE
fix: shorten narrow screen title

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,7 +1166,7 @@
         
         if (width <= 360 && h1) {
           // Only change for ultra-narrow screens
-          h1.innerHTML = '🏆 IIMB Fantasy League 🏆'; // Shortened version
+          h1.innerHTML = '🏆 IIM-M Fantasy League 🏆'; // Shortened version
         } else if (h1) {
           // Restore original for all other screens
           h1.innerHTML = '🏆 IIM Mumbai Fantasy League 🏆'; // Full version


### PR DESCRIPTION
## Summary
- show "🏆 IIM-M Fantasy League 🏆" on ultra-narrow screens while keeping full title elsewhere

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891180faf308324880554798825ce94