### PR TITLE
Load winner data based on FPL season start

### DIFF
--- a/index.html
+++ b/index.html
@@ -1022,11 +1022,6 @@
             document.getElementById("pot-amount").textContent = "--";
           });
 
-        // Load winner data (only if season has started)
-        if (isSeasonStarted()) {
-          loadWinnerData();
-        }
-
         // Add this at the end
         checkTestMode();
       });
@@ -1102,6 +1097,9 @@
           if (headerP) {
             headerP.textContent = "Season 2025-26 - Live Updates";
           }
+
+          // Load winner data now that the season has started
+          loadWinnerData();
 
           // Show gameweek countdown
           if (gameweek) {
@@ -1241,14 +1239,6 @@
               .forEach((label) => (label.style.display = "block"));
           }
         }
-      }
-
-      function isSeasonStarted() {
-        // This function is now handled by FPL API data
-        // Keeping for backward compatibility
-        const fallbackDate = new Date("2025-08-15T17:30:00Z");
-        const currentDate = new Date();
-        return currentDate >= fallbackDate;
       }
 
       function loadWinnerData() {


### PR DESCRIPTION
## Summary
- trigger winner stats only when FPL season start date has passed
- drop obsolete `isSeasonStarted` helper and manual check

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689135b6a2ac8324b77dafe7ccc62d7b