### PR TITLE
Clarify season start fallback comment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1077,6 +1077,10 @@
 
       function handleSeasonDisplay(seasonStartDate, gameweek = null) {
         const currentDate = new Date();
+        // Temporary fallback: checks if the season has started when FPL data
+        // isn't available or fails to return a valid gameweek. Compares the
+        // provided start date (from API or hardcoded fallback) with the
+        // current time.
         const isSeasonStarted = currentDate >= seasonStartDate;
 
         console.log("Season start date (from FPL):", seasonStartDate);


### PR DESCRIPTION
## Summary
- clarify `isSeasonStarted` fallback comment to describe when the check is used if FPL API data fails or is missing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689138666bb08324a9764897568d392e