### PR TITLE
Fix winner summary count

### DIFF
--- a/index.html
+++ b/index.html
@@ -854,9 +854,10 @@
           // Show summary
           const totalWinners = winners.length;
           const totalPrizeMoney = winners.reduce((sum, winner) => sum + winner.totalPrizeWon, 0);
-          
-          document.getElementById('test-winner-summary').innerHTML = 
-              `Showing top 6 of ${totalWinners} winners • Total prize money distributed: ₹${totalPrizeMoney.toLocaleString('en-IN')}`;
+          const displayCount = Math.min(6, totalWinners);
+
+          document.getElementById('test-winner-summary').innerHTML =
+              `Showing top ${displayCount} of ${totalWinners} winners • Total prize money distributed: ₹${totalPrizeMoney.toLocaleString('en-IN')}`;
       }
 
       document.addEventListener('DOMContentLoaded', function() {
@@ -1155,9 +1156,10 @@
         // Show summary
         const totalWinners = winners.length;
         const totalPrizeMoney = winners.reduce((sum, winner) => sum + winner.totalPrizeWon, 0);
-        
-        document.getElementById('winner-summary').innerHTML = 
-          `Showing top 6 of ${totalWinners} winners • Total prize money distributed: ₹${totalPrizeMoney.toLocaleString('en-IN')}`;
+        const displayCount = Math.min(6, totalWinners);
+
+        document.getElementById('winner-summary').innerHTML =
+          `Showing top ${displayCount} of ${totalWinners} winners • Total prize money distributed: ₹${totalPrizeMoney.toLocaleString('en-IN')}`;
       }
 
       function adjustForZFold() {


### PR DESCRIPTION
## Summary
- Correct winner summary to show actual displayed count instead of always 6
- Provide accurate top winner summary in test mode

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68911639b30c8324b01504863ccce1d0