### PR TITLE
Robust caching + fingerprinted build + SW update prompt

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,0 +1,26 @@
+# Netlify-style headers (ignored by GitHub Pages)
+
+# HTML: short cache, ensure revalidation
+/*
+  Cache-Control: no-cache, no-store, must-revalidate
+  Pragma: no-cache
+  Expires: 0
+
+# Service worker: always revalidate
+/service-worker.js
+  Cache-Control: no-cache, no-store, must-revalidate
+
+# Precache manifest and version file: short cache
+/precache-manifest.json
+  Cache-Control: no-cache
+/version.js
+  Cache-Control: no-cache
+
+# Hashed assets: long cache with immutable
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+/css/*
+  Cache-Control: public, max-age=31536000, immutable
+/js/*
+  Cache-Control: public, max-age=31536000, immutable
+

--- a/docs/CACHING_AND_DEPLOYMENT.md
+++ b/docs/CACHING_AND_DEPLOYMENT.md
@@ -1,0 +1,78 @@
+# 🚀 Caching & Deployment Strategy
+
+This document explains how we ensure returning users always see the latest site with fast loads and reliable offline behavior.
+
+## Overview
+
+- Single source of version truth: `package.json` → `version.js`
+- Fingerprinted assets: content-hashed CSS/JS outputs in `docs/`
+- Service Worker strategy: network‑first for HTML; cache‑first for static assets
+- Update prompt: banner invites users to refresh when a new version is ready
+- Headers: Netlify `_headers` for optimal cache control (GitHub Pages ignores headers but hashed assets still work)
+
+## Versioning
+
+- The script `scripts/set-version.js` writes `version.js` with `SITE_VERSION` from `package.json`.
+- `service-worker.js` imports `version.js` and names its cache `fpl-iim-mumbai-v${SITE_VERSION}`.
+- Pages load `/version.js` so UI and diagnostics can read the current version.
+
+## Build & Fingerprinting
+
+Command: `npm run build`
+
+What it does:
+- Writes `version.js` from `package.json`.
+- Copies the site to `docs/` (excluding dev folders).
+- Appends content hashes to CSS/JS filenames (e.g., `styles.abc12345.css`).
+- Rewrites `index.html` and `winners.html` to reference the hashed assets.
+- Generates `/precache-manifest.json` used by the Service Worker during install.
+
+Why this helps:
+- Browsers can cache hashed assets for a year (`immutable`), yet fetch fresh copies whenever content changes.
+- HTML is short‑cached, so a normal refresh picks up new versions.
+
+## Service Worker
+
+- Navigations (HTML) use network‑first with an offline fallback page.
+- Static assets use cache‑first with background revalidation.
+- On install, the SW precaches default URLs plus any files in `/precache-manifest.json` (hashed build outputs).
+- On activate, it removes old cache versions automatically.
+
+## Update Prompt
+
+- `js/sw-update.js` registers the SW and listens for updates.
+- When a new SW is installed and waiting, a small banner appears: “New version available” with a Refresh button.
+- Clicking Refresh sends `SKIP_WAITING` to the SW and reloads once the new version controls the page.
+
+## Headers (Netlify)
+
+The `_headers` file configures optimal caching on Netlify:
+
+- HTML + `service-worker.js`: `no-cache, no-store, must-revalidate`
+- Hashed assets (`/css`, `/js`, `/assets`): `public, max-age=31536000, immutable`
+
+GitHub Pages ignores custom headers, but the hashing still ensures fresh assets.
+
+## GitHub Pages
+
+- Set Pages source to “Deploy from a branch” → your default branch, folder `/docs`.
+- After `npm run build`, commit and push `docs/` to publish.
+
+## Local Development
+
+- Quick serve: `npm run dev` (or `python3 -m http.server`).
+- Apply version only: `npm run version:apply` (updates `version.js` for SW cache name bump).
+
+## Release Checklist (TL;DR)
+
+1. Bump `package.json` version.
+2. Run `npm run build`.
+3. Commit changes (including `docs/`) and push.
+4. Verify the site updates; ensure the update banner appears on old tabs.
+
+## Troubleshooting
+
+- Seeing stale pages: do a hard reload, or wait for the banner and click Refresh.
+- SW not updating: confirm `version.js` changed and `CACHE_NAME` reflects the new version.
+- Hashed assets missing: ensure `npm run build` ran and `docs/` contains hashed files.
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,35 @@
 # 📝 Changelog - Fantasy League Website
 
+## [1.4.5] - 2025-09-10 – Robust Caching + Fingerprinted Build + SW Update Prompt
+
+### 🚀 New
+
+- Single-source version via `version.js` generated from `package.json` (used by pages and Service Worker).
+- Build pipeline that outputs a fingerprinted site to `docs/` with content-hashed CSS/JS and a precache manifest.
+- In-page “New version available” banner; one click refreshes to the latest version when the SW updates.
+
+### 🧩 Changes
+
+- Service Worker now uses a network-first strategy for HTML navigations so normal refresh gets fresh pages, with offline fallback.
+- SW cache name derives from site version; old caches are cleaned on activate.
+- HTML now references a shared `version.js` and delegates SW registration to `js/sw-update.js`.
+
+### 🧪 Deployment & Caching
+
+- GitHub Pages compatible: `npm run build` writes a ready-to-serve site to `docs/` (Pages can point to `/docs`).
+- Netlify-compatible `_headers` file added:
+  - HTML + `service-worker.js`: `no-cache`
+  - Hashed assets under `/css`, `/js`, `/assets`: `public, max-age=31536000, immutable`
+
+### 📂 Files (key)
+
+- Added: `version.js`, `js/sw-update.js`, `scripts/set-version.js`, `scripts/build.js`, `_headers`
+- Updated: `service-worker.js`, `index.html`, `winners.html`, `package.json`
+
+### 🔎 Notes
+
+- See `docs/CACHING_AND_DEPLOYMENT.md` for workflow and rollout steps.
+
 ## [1.4.4] - 2025-09-10 – Header Autohide + Winners UX Polish
 
 ### 🚀 New

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -18,6 +18,7 @@
 ### Release Information
 
 - **[📝 CHANGELOG.md](CHANGELOG.md)** - Public release notes and version history
+- **[🚀 CACHING_AND_DEPLOYMENT.md](CACHING_AND_DEPLOYMENT.md)** - Build, caching, and rollout strategy
 
 ## 🔒 Internal Documentation
 
@@ -40,6 +41,7 @@ docs/
 ├── CONTRIBUTING.md    # Contributor guidelines
 ├── SETUP_GUIDE.md     # Local development setup
 ├── CHANGELOG.md       # Public release notes
+├── CACHING_AND_DEPLOYMENT.md  # Build and caching workflow
 └── archive/          # Archived internal documents
 ```
 

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
     />
 
     <!-- CSS: Consolidated foundation (variables, fonts, base, spacing) -->
-    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css?v=1.0.5" />
 
     <!-- Critical CSS: minimal above-the-fold styles for stable first paint -->
     <style>
@@ -291,7 +291,7 @@
     <!-- 6. Responsive: merged into styles.css -->
 
     <!-- 7. Fallback CSS (loads only if external resources fail) -->
-    <link rel="stylesheet" href="css/fallbacks.css" id="fallback-css" disabled />
+    <link rel="stylesheet" href="css/fallbacks.css?v=1.0.5" id="fallback-css" disabled />
 
     <!-- Load test/admin wrappers only when needed to reduce main bundle size -->
     <script>
@@ -299,7 +299,7 @@
         var qp = new URLSearchParams(location.search);
         if (qp.get('test') === 'true' || qp.get('admin') === 'true') {
           var s = document.createElement('script');
-          s.src = 'js/test-admin-wrappers.js';
+          s.src = 'js/test-admin-wrappers.js?v=1.0.5';
           s.defer = true;
           document.head.appendChild(s);
         }
@@ -804,14 +804,16 @@
     </div>
 
     <!-- === JS: MODULAR STRUCTURE === -->
+    <script src="/version.js?v=1" defer></script>
     <!-- Core modules -->
-    <script src="js/error-handler.js" defer></script>
-    <script src="js/utils.js" defer></script>
-    <script src="js/data-loader.js" defer></script>
-    <script src="js/ui-manager.js" defer></script>
-    <script src="js/header-scroll.js" defer></script>
-    <script src="js/countdown.js" defer></script>
-    <script src="js/prize-structure.js" defer></script>
+    <script src="js/error-handler.js?v=1.0.5" defer></script>
+    <script src="js/utils.js?v=1.0.5" defer></script>
+    <script src="js/data-loader.js?v=1.0.5" defer></script>
+    <script src="js/ui-manager.js?v=1.0.5" defer></script>
+    <script src="js/header-scroll.js?v=1.0.5" defer></script>
+    <script src="js/countdown.js?v=1.0.5" defer></script>
+    <script src="js/prize-structure.js?v=1.0.5" defer></script>
+    <script src="js/sw-update.js?v=1" defer></script>
     <!-- Main application script -->
     <script>
       /*
@@ -1775,17 +1777,7 @@
         }
       }
 
-      // Service worker registration for offline support (if service-worker.js exists)
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker
-            .register('/service-worker.js')
-            .then((registration) => console.log('SW registered:', registration))
-            .catch((registrationError) =>
-              console.log('SW registration failed:', registrationError)
-            );
-        });
-      }
+      // Service worker registration moved to js/sw-update.js (with update prompt)
 
       // =============== LEADERBOARD FUNCTIONS ===============
 

--- a/js/sw-update.js
+++ b/js/sw-update.js
@@ -1,0 +1,80 @@
+/* Service Worker registration + in-page update prompt */
+(function () {
+  if (!('serviceWorker' in navigator)) return;
+
+  function createUpdateBanner(onReload) {
+    var banner = document.createElement('div');
+    banner.setAttribute('role', 'status');
+    banner.setAttribute('aria-live', 'polite');
+    banner.style.cssText = [
+      'position:fixed',
+      'left:50%',
+      'bottom:16px',
+      'transform:translateX(-50%)',
+      'background:#37003c',
+      'color:#fff',
+      'padding:10px 16px',
+      'border-radius:8px',
+      'box-shadow:0 4px 16px rgba(0,0,0,.2)',
+      'z-index:9999',
+      'display:flex',
+      'gap:12px',
+      'align-items:center',
+      'font:500 14px system-ui, -apple-system, Segoe UI, Roboto, sans-serif',
+    ].join(';');
+    banner.innerHTML = '<span>New version available.</span>';
+    var btn = document.createElement('button');
+    btn.textContent = 'Refresh';
+    btn.style.cssText =
+      'background:#fff;color:#37003c;border:none;border-radius:6px;padding:6px 10px;cursor:pointer;font-weight:600';
+    btn.onclick = function () {
+      onReload && onReload();
+    };
+    banner.appendChild(btn);
+    document.body.appendChild(banner);
+    return banner;
+  }
+
+  window.addEventListener('load', function () {
+    navigator.serviceWorker
+      .register('/service-worker.js')
+      .then(function (reg) {
+        // Listen for updates
+        if (reg.waiting) {
+          // Already waiting — prompt immediately
+          promptToRefresh(reg.waiting);
+        }
+        reg.addEventListener('updatefound', function () {
+          var newWorker = reg.installing;
+          if (!newWorker) return;
+          newWorker.addEventListener('statechange', function () {
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              promptToRefresh(newWorker);
+            }
+          });
+        });
+
+        // If the controller changes, reload once to get the fresh page
+        var refreshing = false;
+        navigator.serviceWorker.addEventListener('controllerchange', function () {
+          if (refreshing) return;
+          refreshing = true;
+          window.location.reload();
+        });
+      })
+      .catch(function (err) {
+        console.log('SW registration failed:', err);
+      });
+  });
+
+  function promptToRefresh(worker) {
+    createUpdateBanner(function () {
+      // Ask the waiting SW to activate immediately
+      if (worker && worker.postMessage) {
+        worker.postMessage({ type: 'SKIP_WAITING' });
+      } else if (navigator.serviceWorker.controller) {
+        navigator.serviceWorker.controller.postMessage({ type: 'SKIP_WAITING' });
+      }
+    });
+  }
+})();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adigunners-github-io",
-  "version": "1.0.0",
+  "version": "1.0.6",
   "description": "IIM Mumbai Fantasy Premier League - Automated fantasy football league management system",
   "private": true,
   "scripts": {
@@ -19,7 +19,9 @@
     "spec:new": "node .codex/bin/new-spec.js",
     "spec:tasks": "node .codex/bin/new-tasks.js",
     "codex:date": "node .codex/bin/date-checker.js",
-    "codex:new": "node .codex/bin/codex-workflow.js"
+    "codex:new": "node .codex/bin/codex-workflow.js",
+    "version:apply": "node scripts/set-version.js",
+    "build": "node scripts/build.js"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/version.js
+++ b/version.js
@@ -1,0 +1,11 @@
+// Shared version constant for both window (pages) and worker scope
+(function(global){
+  var v = '1.0.6';
+  try {
+    // In window context
+    if (typeof window !== 'undefined') window.SITE_VERSION = v;
+    // In worker context
+    if (typeof global !== 'undefined') global.SITE_VERSION = v;
+  } catch (_) {}
+})(typeof self !== 'undefined' ? self : this);
+

--- a/winners.html
+++ b/winners.html
@@ -47,7 +47,7 @@
 
     <!-- MODULAR CSS ARCHITECTURE (standardized async loading like index.html) -->
     <!-- 1. Foundation: Consolidated (variables, fonts, base, spacing) -->
-    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css?v=1.0.5" />
 
     <!-- 2. Layout: Core layout and spacing (merged into styles.css) -->
 
@@ -55,10 +55,10 @@
     <link
       rel="preload"
       as="style"
-      href="assets/css/components/table.css"
+      href="assets/css/components/table.css?v=1.0.5"
       onload="this.onload=null;this.rel='stylesheet'"
     />
-    <noscript><link rel="stylesheet" href="assets/css/components/table.css" /></noscript>
+    <noscript><link rel="stylesheet" href="assets/css/components/table.css?v=1.0.5" /></noscript>
     <!-- header.css merged into styles.css -->
 
     <!-- 4. Page-specific (async loading for non-critical styles) -->
@@ -69,7 +69,7 @@
     <!-- 5. Responsive (merged into styles.css) -->
 
     <!-- 6. Fallback CSS (loads only if external resources fail; kept last) -->
-    <link rel="stylesheet" href="css/fallbacks.css" id="fallback-css" disabled />
+    <link rel="stylesheet" href="css/fallbacks.css?v=1.0.5" id="fallback-css" disabled />
 
     <!-- Critical CSS: Above-the-fold styles for stable first paint -->
     <style>
@@ -478,13 +478,13 @@
       // Identify this as winners page to prevent UI manager from running index.html-specific code
       window.FPL_PAGE_TYPE = 'winners';
     </script>
-    <script src="js/error-handler.js" defer></script>
-    <script src="js/utils.js" defer></script>
-    <script src="js/data-loader.js" defer></script>
-    <script src="js/ui-manager.js" defer></script>
-    <script src="js/header-scroll.js" defer></script>
-    <script src="js/countdown.js" defer></script>
-    <script src="js/prize-structure.js" defer></script>
+    <script src="js/error-handler.js?v=1.0.5" defer></script>
+    <script src="js/utils.js?v=1.0.5" defer></script>
+    <script src="js/data-loader.js?v=1.0.5" defer></script>
+    <script src="js/ui-manager.js?v=1.0.5" defer></script>
+    <script src="js/header-scroll.js?v=1.0.5" defer></script>
+    <script src="js/countdown.js?v=1.0.5" defer></script>
+    <script src="js/prize-structure.js?v=1.0.5" defer></script>
 
     <!-- Winners page module loader -->
     <script type="module" src="js/winners-module.js" defer></script>
@@ -639,18 +639,8 @@
       });
     </script>
 
-    <!-- Service worker registration for offline support (match index.html) -->
-    <script>
-      if ('serviceWorker' in navigator) {
-        window.addEventListener('load', () => {
-          navigator.serviceWorker
-            .register('/service-worker.js')
-            .then((registration) => console.log('SW registered:', registration))
-            .catch((registrationError) =>
-              console.log('SW registration failed:', registrationError)
-            );
-        });
-      }
-    </script>
+    <!-- Version + SW update handling -->
+    <script src="/version.js?v=1" defer></script>
+    <script src="js/sw-update.js?v=1" defer></script>
   </body>
 </html>


### PR DESCRIPTION
Summary\n- Network-first HTML navigations in service worker; cache-first for static assets\n- Single-source version via version.js (from package.json); SW cache name derives from version\n- Build script fingerprints CSS/JS and writes to docs/ with precache-manifest.json\n- Netlify-compatible _headers for strong cache control\n- Update banner prompts users to refresh when a new SW is ready\n\nDocs\n- Added docs/CACHING_AND_DEPLOYMENT.md\n- Updated docs/CHANGELOG.md (1.4.5) and docs/INDEX.md link\n\nDeployment\n- If using GitHub Pages, set Pages source to /docs after running npm run build\n- If using Netlify, _headers will be honored automatically\n\nVerification\n- Normal refresh shows fresh HTML\n- Assets update due to hashing; SW precaches manifest entries\n- Update banner appears on old tabs after deploy; clicking Refresh activates new SW\n\nNotes\n- Local: npm run dev; Version bump: edit package.json then npm run version:apply\n- Build: npm run build (generates docs/ with hashed assets)